### PR TITLE
Change date parsing

### DIFF
--- a/libsgfdata/__init__.py
+++ b/libsgfdata/__init__.py
@@ -103,6 +103,11 @@ def _conv(k, v):
 
     if k in date_fields:
         try:
+            if len(v) >= 8:
+                return dateutil.parser.isoparse(v).date()
+        except ValueError as exception:
+            logger.debug("Unable to parse date as iso %s: %s" % (v, exception))
+        try:
             return dateutil.parser.parse(v, parserinfo=dateutil.parser.parserinfo(dayfirst=True)).date()
         except Exception as e:
             #fixme: make this per file, not per depth row of data

--- a/tests/unit/test_dates.py
+++ b/tests/unit/test_dates.py
@@ -1,0 +1,16 @@
+import datetime
+
+import pytest as pytest
+
+import libsgfdata as sgf
+
+class TestDates:
+
+    @pytest.mark.parametrize("key, date_string, expected_result", [
+        ("AK", "200208221132", datetime.datetime(2002, 8, 22, 11, 32)),
+        ("HD", "20120105", datetime.date(2012, 1, 5)),
+        ("HD", "09/04/99", datetime.date(1999, 4, 9)),
+        ("HD", "27.06.2014", datetime.date(2014, 6, 27)),
+    ])
+    def test_dates(self, key, date_string, expected_result):
+        assert expected_result == sgf._conv(key, date_string)

--- a/tests/unit/test_dates.py
+++ b/tests/unit/test_dates.py
@@ -1,6 +1,6 @@
 import datetime
 
-import pytest as pytest
+import pytest
 
 import libsgfdata as sgf
 


### PR DESCRIPTION
Change the date parsing to first try to parse as ISO-8601 (YYYYMMDD) if the string is at least 8 characters long. If the first attempt fails or the date string is shorter than 8 characters, then use the Scandinavian parser (DDMMYY).

Fix #16 