### PR TITLE
Ensure at least one digit before the float regexp match

### DIFF
--- a/libsgfdata/__init__.py
+++ b/libsgfdata/__init__.py
@@ -75,7 +75,7 @@ unmethods = methods.reset_index().set_index("ident")
 uncomments = comments.reset_index().set_index("ident")
 undata_flags = data_flags.reset_index().set_index("ident")
 
-_RE_FLOAT = re.compile(r"^\s*[-+]?[0-9]*(\.[0-9]*)?([eE][-+]?[0-9]+)?\s*$")
+_RE_FLOAT = re.compile(r"^\s*[-+]?([0-9]+(\.[0-9]*)?|\.[0-9]+)([eE][-+]?[0-9]+)?\s*$")
 _RE_INT = re.compile(r"^\s*[-+]?[0-9]+\s*$")
 # Fields are generally separated by "," and contain a single "="
 # separating the key from the value. However, some fields have values


### PR DESCRIPTION
Please revise this PR. Reading and writing regular expressions are on the edge of my mental capacity.

The core change is from the first digits group `[0-9]*` to `[0-9]+` (must at least be a digit in the string) with optional decimals following.  After the or (`|`) is an alternative with only decimals starting with a literal dot (`\.`). Example: `'.32'`.

Fix #19 