### PR TITLE
Skip empty rows

### DIFF
--- a/libsgfdata/parser.py
+++ b/libsgfdata/parser.py
@@ -71,6 +71,8 @@ def _parse_raw_from_file(f, encoding=None):
     block = None
     for row in f:
         row = row.rstrip("\n\r")
+        if not row:
+            continue
         if row == "$":
             blocks = {"£":[], "$":[], "#":[], "€": []}
             sections.append(blocks)


### PR DESCRIPTION
We encounter sgf files that end with a couple of empty lines. Is it OK to skip those during your parsing?