### PR TITLE
bugfix for bad assert statement in __init__.py

### DIFF
--- a/libsgfdata/__init__.py
+++ b/libsgfdata/__init__.py
@@ -241,7 +241,7 @@ class SGFData(object):
     def positions(self):
         import geopandas as gpd
 
-        assert self.main
+        assert len(self.main)>0,'self.main DataFrame is either missing or is empty'
         
         projection = self.projection
         if projection is None: raise ValueError("SGF file has boreholes in multiple projections, or projection not specified.")

--- a/libsgfdata/__init__.py
+++ b/libsgfdata/__init__.py
@@ -241,6 +241,7 @@ class SGFData(object):
     def positions(self):
         import geopandas as gpd
 
+        assert self.main is not None, 'self.main DataFrame is None, so cannot access geographic attributes like positions, area, or bounds'
         assert len(self.main)>0,'self.main DataFrame is either missing or is empty'
         
         projection = self.projection


### PR DESCRIPTION
I was getting this error message before when calling the bounds, area, and positions methods: 

`ValueError: The truth value of a DataFrame is ambiguous. Use a.empty, a.bool(), a.item(), a.any() or a.all().`