### PR TITLE
Migrate off pkg_resources to importlib (v0.0.24)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,0 +1,14 @@
+# Changelog
+
+## 0.0.24
+
+### Changed
+- Migrate off `pkg_resources` (removed in setuptools 81) to `importlib.resources`
+  for loading bundled CSV metadata; removed unused `pkg_resources` imports in
+  `parser.py` and `dumper.py`.
+
+### Fixed (since 0.0.23)
+- Allow `z_orig` to be not-null even when `z_coordinate` is null; stop assuming
+  `id_col == 'investigation_point'`.
+- Downgrade missing-`z_orig` `ValueError` to a warning.
+- Handle a mix of `z_coordinate`/`z_orig` NaN vs non-NaN values in the normalizer.

--- a/libsgfdata/dumper.py
+++ b/libsgfdata/dumper.py
@@ -1,5 +1,4 @@
 import re
-import pkg_resources
 import pandas as pd
 import numpy as np
 import slugify

--- a/libsgfdata/metadata.py
+++ b/libsgfdata/metadata.py
@@ -1,5 +1,5 @@
 import re
-import pkg_resources
+from importlib.resources import files
 import pandas as pd
 import numpy as np
 import slugify
@@ -18,19 +18,19 @@ na_values = ['', '#N/A', '#N/A N/A', '#NA', '-1.#IND', '-1.#QNAN', '-NaN', '-nan
 def _read_csv(f):
     return pd.read_csv(f, na_values=na_values, keep_default_na=False).set_index("code").sort_index()
 
-with pkg_resources.resource_stream("libsgfdata", "method.csv") as f:
+with files("libsgfdata").joinpath("method.csv").open("rb") as f:
     method = _read_csv(f)
-with pkg_resources.resource_stream("libsgfdata", "main.csv") as f:
+with files("libsgfdata").joinpath("main.csv").open("rb") as f:
     main = _read_csv(f)
-with pkg_resources.resource_stream("libsgfdata", "data.csv") as f:
+with files("libsgfdata").joinpath("data.csv").open("rb") as f:
     data = _read_csv(f)
 block_metadata = {"method": method, "main": main, "data": data}
     
-with pkg_resources.resource_stream("libsgfdata", "methods.csv") as f:
+with files("libsgfdata").joinpath("methods.csv").open("rb") as f:
     methods = _read_csv(f)
-with pkg_resources.resource_stream("libsgfdata", "comments.csv") as f:
+with files("libsgfdata").joinpath("comments.csv").open("rb") as f:
     comments = _read_csv(f)
-with pkg_resources.resource_stream("libsgfdata", "data-flags.csv") as f:
+with files("libsgfdata").joinpath("data-flags.csv").open("rb") as f:
     data_flags = _read_csv(f)
 
 

--- a/libsgfdata/parser.py
+++ b/libsgfdata/parser.py
@@ -1,5 +1,4 @@
 import re
-import pkg_resources
 import pandas as pd
 import numpy as np
 import slugify

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ import setuptools
 
 setuptools.setup(
     name='libsgfdata',
-    version='0.0.23',
+    version='0.0.24',
     description='Parser for Swedish Geotechnical Society data format',
     long_description="""Parser for data from geotechnical field
     investigations in the data format specified in Report 3:2012E from


### PR DESCRIPTION
Part of emerald-geomodelling/emerald-installer#19. Replaces `pkg_resources.resource_stream` with `importlib.resources.files(...).open('rb')` (binary stream, verified drop-in equivalent). Version bump to 0.0.24 + CHANGES. setuptools>=81 dropped pkg_resources.

🤖 Generated with [Claude Code](https://claude.com/claude-code)