### PR TITLE
v.0.0.25 - pandas>2 and pandas 3 fixes

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,21 @@
 # Changelog
 
+## 0.0.25
+
+### Fixed
+- Make coordinate normalization work on pandas 3.x and silence the
+  `DataFrameGroupBy.apply operated on the grouping columns` `FutureWarning` on
+  pandas 2.2+ (#50). The two `groupby(...).apply(...)` calls in `normalizer.py`
+  read the grouping columns (`projection_orig`, `projection`) from inside the
+  group frame, which pandas 3.0 excludes by default (raising `AttributeError`)
+  and pandas 2.2+ warns about. Replaced them with a version-agnostic
+  `_apply_by_group` helper that keeps the grouping columns available and
+  preserves original row order, working across pandas 1.x/2.x/3.x without the
+  `include_groups` keyword.
+
+### Changed
+- Require `pandas>=2`.
+
 ## 0.0.24
 
 ### Changed

--- a/libsgfdata/normalizer.py
+++ b/libsgfdata/normalizer.py
@@ -7,6 +7,25 @@ import numpy as np
 
 logger = logging.getLogger(__name__)
 
+def _apply_by_group(df, by, func):
+    """Apply ``func(group_df, key)`` per group of ``df.groupby(by)`` and concat,
+    preserving the original row order.
+
+    A drop-in replacement for ``df.groupby(by, group_keys=False).apply(func)`` that
+    behaves identically across pandas 1.x / 2.x / 3.x: the grouping columns stay
+    present in ``group_df`` (so callers may still read them) and no
+    ``include_groups`` FutureWarning is emitted. Rows whose grouping key is NaN are
+    dropped, matching groupby's default ``dropna=True``. Assumes ``df`` has a unique
+    index (true for ``sgf.main``).
+    """
+    grouped = df.groupby(by)
+    parts = [func(df.iloc[pos], key) for key, pos in grouped.indices.items()]
+    if not parts:
+        return df.iloc[0:0]
+    result = pd.concat(parts)
+    kept = set(result.index)
+    return result.reindex([i for i in df.index if i in kept])
+
 def _download_transformer_grids(innproj, utproj):
     from pyproj.transformer import TransformerGroup
     tg = TransformerGroup(innproj, utproj)
@@ -54,7 +73,9 @@ def normalize_coordinates(sgf, projection=None, **kw):
         if 'z_coordinate' in sgf.main.columns:
             coords_new['z_coordinate'] = sgf.main['z_coordinate'].copy()
 
-        coords_reprojected_from_orig = sgf.main.groupby(["projection_orig","projection"], group_keys=False).apply( lambda x: reproject_coords_orig_to_new_crs(x, x.projection_orig.iloc[0], x.projection.iloc[0]))
+        coords_reprojected_from_orig = _apply_by_group(
+            sgf.main, ["projection_orig", "projection"],
+            lambda x, key: reproject_coords_orig_to_new_crs(x, x.projection_orig.iloc[0], x.projection.iloc[0]))
 
         if coords_reprojected_from_orig.shape[1]!=coords_new.shape[1]:
             msg = f'one set of stored coordinates is missing a z coordinate, so only x-y coordinates will be verified. ' \
@@ -186,7 +207,9 @@ def normalize_coordinates(sgf, projection=None, **kw):
         return out
 
     validate_stored_original_and_new_coordinates_match_within_tolerance(sgf, **kw)
-    sgf.main = sgf.main.groupby("projection_orig", group_keys=False).apply(lambda x: reproject_to_all_crs(x, projection))
+    sgf.main = _apply_by_group(
+        sgf.main, "projection_orig",
+        lambda x, key: reproject_to_all_crs(x, projection))
     sgf.main["projection"] = projection
 
 def normalize_stop_code(sgf):

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ import setuptools
 
 setuptools.setup(
     name='libsgfdata',
-    version='0.0.24',
+    version='0.0.25',
     description='Parser for Swedish Geotechnical Society data format',
     long_description="""Parser for data from geotechnical field
     investigations in the data format specified in Report 3:2012E from
@@ -20,7 +20,7 @@ setuptools.setup(
     package_data={'libsgfdata': ['*/*.csv']},
     install_requires=[
         "numpy",
-        "pandas",
+        "pandas>=2",
         "python-slugify",
         "python-dateutil",
         "charset-normalizer"

--- a/tests/unit/test_normalizer.py
+++ b/tests/unit/test_normalizer.py
@@ -1,0 +1,64 @@
+import warnings
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from libsgfdata.normalizer import _apply_by_group
+
+
+class TestApplyByGroup:
+
+    def _frame(self):
+        # Two CRS groups plus one row with a NaN grouping key (must be dropped,
+        # matching groupby's default dropna=True). Deliberately interleaved so
+        # row-order preservation is actually exercised.
+        return pd.DataFrame({
+            "projection_orig": [3006, 3007, 3006, np.nan, 3007],
+            "value": [10, 20, 30, 40, 50],
+        })
+
+    def test_preserves_row_order_and_drops_nan_key(self):
+        df = self._frame()
+        result = _apply_by_group(df, "projection_orig", lambda x, key: x)
+        # NaN-key row (index 3) dropped; remaining rows keep their original order.
+        assert list(result.index) == [0, 1, 2, 4]
+        assert list(result["value"]) == [10, 20, 30, 50]
+
+    def test_grouping_column_present_in_group_frame(self):
+        df = self._frame()
+        seen_columns = []
+
+        def capture(group_df, key):
+            seen_columns.append(list(group_df.columns))
+            return group_df
+
+        _apply_by_group(df, "projection_orig", capture)
+        # The grouping column must remain available to the callback on every group.
+        assert all("projection_orig" in cols for cols in seen_columns)
+
+    def test_key_passed_for_single_and_multi_key(self):
+        df = self._frame()
+
+        single_keys = []
+        _apply_by_group(df, "projection_orig",
+                        lambda x, key: single_keys.append(key) or x)
+        assert set(single_keys) == {3006, 3007}
+
+        multi_keys = []
+        df2 = df.assign(projection=4326)
+        _apply_by_group(df2, ["projection_orig", "projection"],
+                        lambda x, key: multi_keys.append(key) or x)
+        assert set(multi_keys) == {(3006, 4326), (3007, 4326)}
+
+    def test_no_future_warning(self):
+        df = self._frame()
+        with warnings.catch_warnings():
+            warnings.simplefilter("error", FutureWarning)
+            _apply_by_group(df, "projection_orig", lambda x, key: x)
+
+    def test_empty_input_returns_empty_frame(self):
+        df = self._frame().iloc[0:0]
+        result = _apply_by_group(df, "projection_orig", lambda x, key: x)
+        assert len(result) == 0
+        assert list(result.columns) == list(df.columns)


### PR DESCRIPTION
Closes #50.

## Problem

`normalize_coordinates` in `libsgfdata/normalizer.py` used two
`groupby(...).apply(lambda x: ...)` calls whose applied functions read the
**grouping columns** (`projection_orig`, `projection`) from inside the group
frame. Pandas changed this behavior:

- **pandas 2.2.x**: grouping columns are still passed but emit
  `FutureWarning: DataFrameGroupBy.apply operated on the grouping columns...`
- **pandas 3.0**: grouping columns are **excluded** from the group frame by
  default, so `x.projection_orig` raises `AttributeError`, and
  `reproject_to_all_crs` loses the `projection_orig` column entirely.

## Fix

Added a small module-level helper `_apply_by_group(df, by, func)` — a drop-in
for `df.groupby(by, group_keys=False).apply(...)` that iterates groups via
`grouped.indices` + `df.iloc[pos]`, so the grouping columns **stay present** in
each group frame. It preserves the original row order and drops NaN-key rows
(matching `dropna=True`). The two call sites now use it; the inner reprojection
functions are unchanged.

This deliberately avoids the `include_groups` keyword (it only exists in pandas
>= 2.2 and rejects `True` in 3.0), so the code works across pandas 1.x / 2.x / 3.x
with no `FutureWarning`.

## Other changes

- `setup.py`: require `pandas>=2`; version bump to `0.0.25`.
- `CHANGES.md`: 0.0.25 entry.
- New `tests/unit/test_normalizer.py` covering row-order preservation, NaN-key
  dropping, grouping-column presence, single/multi-key group keys, absence of
  `FutureWarning`, and empty input.

## Verification

- Helper unit tests pass on **pandas 2.3.3** and **pandas 3.0.3**.
- End-to-end `normalize_coordinates()` (two CRS groups, with `pyproj`, with
  `FutureWarning` escalated to an error) passes on both versions; output columns
  (`projection_orig`, `x_web`/`y_web`, `lon`/`lat`) and row order preserved.
- Full existing test suite (17 tests) passes on both pandas versions.